### PR TITLE
[Enhancement] Support agent-side multi-chunk repair

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -85,7 +85,7 @@ In `proxy.ini`,
   - `background_task_check_interval`: Time between checks on background task status (in seconds)
 - `misc`: Misc
   - `zmq_thread`: Number of threads in ZeroMQ context 
-  - `repair_at_proxy`: Whether to perform data repair at the proxy (instead of an agent) when the improved repair technique applies
+  - `repair_at_proxy`: Whether to perform data repair at the proxy (instead of an agent)
   - `overwrite_files`: Whether to remove old data chunks for overwrite
   - `reuse_data_connection`: Reuse data connections for chunk transfer
   - `liveness_cache_time`: Time to cache alive liveness status (in seconds)

--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ The Samba server communicates with Nexoedge via TCP/IP sockets.
 
 See the [build and installation guide](INSTALL.md) for the installation instructions.
 
+### Data Repair
+
+Nexoedge supports both proxy-side and agent-side data repair. System administrators can configure either option in the proxy configuration file.
+
 ### System Monitoring Tools
 
 #### Status Report

--- a/docs/user-doc/source/config.rst
+++ b/docs/user-doc/source/config.rst
@@ -93,7 +93,7 @@ In ``proxy.ini``,
     - ``background_task_check_interval``: Time between checks on background task status (in seconds)
 - ``misc``: Misc
     - ``zmq_thread``: Number of threads in ZeroMQ context 
-    - ``repair_at_proxy``: Whether to perform data repair at the proxy (instead of an agent) when the improved repair technique applies
+    - ``repair_at_proxy``: Whether to perform data repair at the proxy (instead of an agent)
     - ``overwrite_files``: Whether to remove old data chunks for overwrite 
     - ``reuse_data_connection``: Reuse data connections for chunk transfer
     - ``liveness_cache_time``: Time to cache alive liveness status (in seconds)

--- a/src/proxy/chunk_manager.cc
+++ b/src/proxy/chunk_manager.cc
@@ -854,6 +854,7 @@ bool ChunkManager::operateOnAliveChunks(const File &file, bool chunkIndicator[],
 }
 
 bool ChunkManager::repairFile(File &file, bool *chunkIndicator, int *spareContainers, int *chunkGroups, int numChunkGroups) {
+    // TODO support partial repair success (some but not all repaired chunks are stored)
 
     // benchmark
     BMRepair *bmRepair = dynamic_cast<BMRepair*>(Benchmark::getInstance().at(file.reqId));
@@ -913,7 +914,7 @@ bool ChunkManager::repairFile(File &file, bool *chunkIndicator, int *spareContai
         inputChunkIndices[i] = inputChunkIds.at(i);
     }
 
-    bool isRepairAtProxy = Config::getInstance().isRepairAtProxy() || numFailedNodes > 1;
+    bool isRepairAtProxy = Config::getInstance().isRepairAtProxy();
     bool isRepairUsingCAR = Config::getInstance().isRepairUsingCAR() && numFailedNodes == 1;
     int numFailedChunks = numFailedNodes * numChunksPerNode;
     // number of failed chunks can be greater than input, e.g., replication


### PR DESCRIPTION
## What is in the pull request?

- Enable the agent-side multi-chunk repair flow

### Brief Description about the Agent-side Multi-chunk Repair Flow

- For each stripe, the proxy sends the repair request to the agent to store the first repaired for data repair.
- After repairing the chunks, the agent stores the first one locally and distributes the remaining to other agents.
- Finally, the agent notifies the proxy of the data repair result.

## Code of Conduct

- [x] By submitting this issue, I agree to follow this project's [Code of Conduct](https://github.com/nexoedge/nexoedge/pull/CODE_OF_CONDUCT.md)