### PR TITLE
[Enhancement] Support generic S3 as storage containers

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -124,16 +124,18 @@ In `agent.ini`,
   - `flush_on_close`: Whether to flush and sync data before file stream close for local file system containers
   - `register_to_proxy`: Whether to register to the list of proxies (in `general.ini`) on start 
 - `container[00-99]`: Data containers
-  - `type`: Container type; local file system: 'fs', Aliyun: 'alibaba', AWS S3: 'aws', Azure: 'azure'
+  - `type`: Container type; local file system: 'fs', Aliyun: 'alibaba', AWS S3: 'aws', Azure: 'azure', Generic S3: 'generic_s3'
   - `id`: Container id, must be *UNIQUE* among all containers of all agents
   - `url`: Location for chunk storage and access
     - Local file system: Directory path 
-    - Aliyun and AWS S3: Bucket name
+    - Aliyun, AWS S3, and generic S3: Bucket name
     - Azure: Storage account connection string
-  - `region`: Region name for Aliyun and AWS S3, e.g. cn-hongkong, ap-east-1
-  - `key_id`: Key ID for Aliyun and AWS S3
-  - `key`: Secret key for Aliyun and AWS S3
+  - `region`: Region name for Aliyun, AWS S3, and generic S3, e.g. cn-hongkong, ap-east-1
+  - `key_id`: Key ID for Aliyun, AWS S3, and generic S3
+  - `key`: Secret key for Aliyun, AWS S3, and generic S3
   - `capacity`: Container capacity
+  - `endpoint`: Endpoint (e.g., https://localhost:59002) for generic S3
+  - `verify_ssl`: Whether to verify the SSL/TLS certificate for an HTTPS endpoint (e.g., https://localhost:59002) for generic S3
 
 ## Storage Class Configuration
 

--- a/docs/user-doc/source/config.rst
+++ b/docs/user-doc/source/config.rst
@@ -134,16 +134,18 @@ In ``agent.ini``,
     - ``flush_on_close``: Whether to flush and sync data before a file stream closes for local file system containers
     - ``register_to_proxy``: Whether to register to the list of proxies (in ``general.ini``) on start 
 - ``container[00-99]``: Data containers
-    - ``type``: Container type; local file system: 'fs', Aliyun: 'alibaba', AWS S3: 'aws', Azure: 'azure'
+    - ``type``: Container type; local file system: 'fs', Aliyun: 'alibaba', AWS S3: 'aws', Azure: 'azure', Generic S3: 'generic_s3'
     - ``id``: Container ID, must be *UNIQUE* among all containers of all agents
     - ``url``: Location for chunk storage and access
         - Local file system: Directory path 
-        - Aliyun and AWS S3: Bucket name
+        - Aliyun, AWS S3, and generic S3: Bucket name
         - Azure: Storage account connection string
-    - ``region``: Region name for Aliyun and AWS S3, e.g. cn-hongkong, ap-east-1
-    - ``key_id``: Key ID for Aliyun and AWS S3
-    - ``key``: Secret key for Aliyun and AWS S3
+    - ``region``: Region name for Aliyun, AWS S3, and generic S3, e.g. cn-hongkong, ap-east-1
+    - ``key_id``: Key ID for Aliyun, AWS S3, and generic S3
+    - ``key``: Secret key for Aliyun, AWS S3, and generic S3
     - ``capacity``: Container capacity
+    - ``endpoint``: Endpoint (e.g., https://localhost:59002) for generic S3
+    - ``verify_ssl``: Whether to verify the SSL/TLS certificate for an HTTPS endpoint (e.g., https://localhost:59002) for generic S3
 
 
 Storage Class Configuration

--- a/sample/agent.ini
+++ b/sample/agent.ini
@@ -21,7 +21,7 @@ flush_on_close = 1
 register_to_proxy = 1
 
 [container01]
-# local file system: fs; Aliyun: alibaba; AWS: aws; Azure: azure;
+# local file system: fs; Aliyun: alibaba; AWS: aws; Azure: azure; Generic S3: generic_s3;
 type = fs
 # container id (internal)
 id = 1
@@ -39,6 +39,10 @@ http_proxy_ip =
 http_proxy_port = 
 # container capacity (in bytes)
 capacity = 1048576
+# for Generic S3 (storage endpoint)
+endpoint = 
+# for Generic S3 (verify SSL certificate)
+verify_ssl = 
 
 # Example for Alibaba Cloud
 #type = alibaba
@@ -66,6 +70,18 @@ capacity = 1048576
 #capacity = 1048576
 #key = [connection string]
 
+# Example for Generic S3
+#type = aws
+#id = 1
+#capacity = 1048576
+#url = ncloud-test-bucket
+#region = ap-east-1
+#key_id = [access key id]
+#key = [secret key]
+#http_proxy_ip = [proxy ip if any]
+#http_proxy_port = [proxy port if any]
+#endpoint = localhost:59002
+#verify_ssl = 0
 
 [container02]
 type = fs
@@ -75,6 +91,8 @@ capacity = 1048576
 region = 
 key_id = 
 key = 
+endpoint = 
+verify_ssl = 1
 
 [container03]
 type = fs
@@ -84,6 +102,8 @@ capacity = 1048576
 region = 
 key_id = 
 key = 
+endpoint = 
+verify_ssl = 1
 
 [container04]
 type = fs
@@ -93,3 +113,5 @@ capacity = 1048576
 region = 
 key_id = 
 key = 
+endpoint = 
+verify_ssl = 1

--- a/src/agent/container/all.hh
+++ b/src/agent/container/all.hh
@@ -4,3 +4,4 @@
 #include "alicloud.hh"
 #include "aws_s3.hh"
 #include "azure_blob.hh"
+#include "generic_s3.hh"

--- a/src/agent/container/aws_s3.cc
+++ b/src/agent/container/aws_s3.cc
@@ -23,7 +23,7 @@
 
 #define OBJ_PATH_MAX (128)
 
-AwsContainer::AwsContainer(int id, std::string bucketName, std::string region, std::string keyId, std::string key, unsigned long int capacity, std::string endpoint, std::string httpProxyIP, unsigned short httpProxyPort, bool useHttp) :
+AwsContainer::AwsContainer(int id, std::string bucketName, std::string region, std::string keyId, std::string key, unsigned long int capacity, std::string endpoint, std::string httpProxyIP, unsigned short httpProxyPort, bool useHttp, bool verifySSL) :
         Container(id, capacity) {
 
     _cred = Aws::Auth::AWSCredentials(keyId.c_str(), key.c_str());
@@ -37,6 +37,10 @@ AwsContainer::AwsContainer(int id, std::string bucketName, std::string region, s
     if (useHttp) {
         clientConfig.scheme = Aws::Http::Scheme::HTTP;
     }
+
+    // override SSL certificate verification if needed
+    clientConfig.verifySSL = verifySSL;
+
     std::shared_ptr<Aws::S3::S3EndpointProviderBase> endpoints = Aws::MakeShared<Aws::S3::S3EndpointProvider>(Aws::S3::S3Client::ALLOCATION_TAG);
     _client = Aws::S3::S3Client (_cred, endpoints, clientConfig);
 

--- a/src/agent/container/aws_s3.hh
+++ b/src/agent/container/aws_s3.hh
@@ -15,7 +15,7 @@
 
 class AwsContainer : public Container {
 public:
-    AwsContainer(int id, std::string bucketName, std::string region, std::string keyId, std::string key, unsigned long int capacity, std::string endpoint = "", std::string httpProxyIP = "", unsigned short httpProxyPort = 0, bool useHttp = false);
+    AwsContainer(int id, std::string bucketName, std::string region, std::string keyId, std::string key, unsigned long int capacity, std::string endpoint = "", std::string httpProxyIP = "", unsigned short httpProxyPort = 0, bool useHttp = false, bool verifySSL = true);
     ~AwsContainer();
 
     /**

--- a/src/agent/container/generic_s3.cc
+++ b/src/agent/container/generic_s3.cc
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "generic_s3.hh"
+
+GenericS3Container::GenericS3Container(int id, std::string bucketName, std::string region, std::string keyId, std::string key, unsigned long int capacity, std::string endpoint, std::string httpProxyIP, unsigned short httpProxyPort, bool useHttp, bool verifySSL)
+        : AwsContainer(id, bucketName, region, keyId, key, capacity, endpoint, httpProxyIP, httpProxyPort, useHttp, verifySSL) {
+}
+

--- a/src/agent/container/generic_s3.hh
+++ b/src/agent/container/generic_s3.hh
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef __GENERIC_CONTAINER_HH__
+#define __GENERIC_CONTAINER_HH__
+
+#include <string>
+
+#include "aws_s3.hh"
+
+class GenericS3Container : public AwsContainer {
+public:
+    GenericS3Container(int id, std::string bucketName, std::string region, std::string keyId, std::string key, unsigned long int capacity, std::string endpoint, std::string httpProxyIP = "", unsigned short httpProxyPort = 0, bool useHttp = false, bool verifySSL = false);
+
+private:
+};
+
+#endif // __GENERIC_CONTAINER_HH__
+

--- a/src/agent/container_manager.cc
+++ b/src/agent/container_manager.cc
@@ -26,6 +26,8 @@ ContainerManager::ContainerManager() {
         std::string region = config.getContainerRegion(i);
         std::string proxyIP = config.getContainerHttpProxyIP(i);
         unsigned short  proxyPort = config.getContainerHttpProxyPort(i);
+        std::string endpoint = config.getContainerEndpoint(i);
+        bool verifySSL = config.getContainerVerifySSL(i);
         switch (ctype) {
         case ContainerType::FS_CONTAINER:
             _containerPtrs[i] = new FsContainer(cid, cstr.c_str(), capacity);
@@ -42,6 +44,10 @@ ContainerManager::ContainerManager() {
         case ContainerType::AZURE_CONTAINER:
             _containerPtrs[i] = new AzureContainer(cid, cstr, key, capacity, proxyIP, proxyPort);
             DLOG(INFO) << "Azure container with id = " << cid << " capacity = " << capacity;
+            break;
+        case ContainerType::GENERIC_S3_CONTAINER:
+            _containerPtrs[i] = new GenericS3Container(cid, cstr, region, keyId, key, capacity, endpoint, proxyIP, proxyPort, /* useHTTP */ false, verifySSL);
+            DLOG(INFO) << "Generic S3 container with id = " << cid << " capacity = " << capacity;
             break;
         default:
             LOG(ERROR) << "Container type " << ctype << " not supported! (container no. = " << i << ")";

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -18,22 +18,23 @@ const char *Config::ContainerTypeName[] = {
     "Alibaba",
     "AWS",
     "Azure",
+    "Generic_S3",          // 5
 
     "Unknown"
 };
 
 const char *Config::LogLevelName[] = {
-    "INFO",
+    "INFO",                // 0
     "WARNING",
     "ERROR",
     "FATAL",
 
-    "Unknown"
+    "Unknown"              // 5
 };
 
 // see DistributionPolicy in common/define.hh
 const char *Config::DistributionPolicyName[] = {
-    "Static",
+    "Static",              // 0
     "Round-Robin",
     "Least-Used",
 
@@ -42,18 +43,18 @@ const char *Config::DistributionPolicyName[] = {
 
 // see ChunkScanSamplingPolicy in common/define.hh
 const char *Config::ChunkScanSamplingPolicyName[] = {
-    "None",
+    "None",               // 0
     "Chunk-level",
     "Stripe-level",
     "File-level",
-    "Container-level",
+    "Container-level",    // 5
 
     "Unknown"
 };
 
 // see MetaStore in common/define.hh
 const char *Config::MetaStoreName[] = {
-    "Redis",
+    "Redis",              // 0
 
     "Unknown"
 };
@@ -210,7 +211,8 @@ void Config::setConfigPath (const char *generalPath, const char *proxyPath, cons
             }
             if (
                 _agent.containers[i].type == ContainerType::AWS_CONTAINER ||
-                _agent.containers[i].type == ContainerType::ALI_CONTAINER
+                _agent.containers[i].type == ContainerType::ALI_CONTAINER ||
+                _agent.containers[i].type == ContainerType::GENERIC_S3_CONTAINER
             ) {
                 sprintf(pname, "container%02d.region", i + 1);
                 _agent.containers[i].region = readString(_agentPt, pname);
@@ -220,14 +222,16 @@ void Config::setConfigPath (const char *generalPath, const char *proxyPath, cons
             if (
                 _agent.containers[i].type == ContainerType::AWS_CONTAINER ||
                 _agent.containers[i].type == ContainerType::ALI_CONTAINER ||
-                _agent.containers[i].type == ContainerType::AZURE_CONTAINER
+                _agent.containers[i].type == ContainerType::AZURE_CONTAINER ||
+                _agent.containers[i].type == ContainerType::GENERIC_S3_CONTAINER
             ) {
                 sprintf(pname, "container%02d.key", i + 1);
                 _agent.containers[i].key = readString(_agentPt, pname);
             }
             if (
                 _agent.containers[i].type == ContainerType::AWS_CONTAINER ||
-                _agent.containers[i].type == ContainerType::AZURE_CONTAINER
+                _agent.containers[i].type == ContainerType::AZURE_CONTAINER ||
+                _agent.containers[i].type == ContainerType::GENERIC_S3_CONTAINER
             ) {
                 try {
                     sprintf(pname, "container%02d.http_proxy_ip", i + 1);
@@ -238,6 +242,18 @@ void Config::setConfigPath (const char *generalPath, const char *proxyPath, cons
                     // no proxy provided
                     _agent.containers[i].httpProxy.ip = "";
                     _agent.containers[i].httpProxy.port = 0; 
+                }
+            }
+            if (
+                _agent.containers[i].type == ContainerType::GENERIC_S3_CONTAINER
+            ) {
+                sprintf(pname, "container%02d.endpoint", i + 1);
+                _agent.containers[i].endpoint = readString(_agentPt, pname);
+                try {
+                    sprintf(pname, "container%02d.verify_ssl", i + 1);
+                    _agent.containers[i].verifySSL = readBool(_agentPt, pname);
+                } catch (std::exception &e) {
+                    _agent.containers[i].verifySSL = false;
                 }
             }
         }
@@ -577,6 +593,20 @@ unsigned short Config::getContainerHttpProxyPort(int i) const {
     if (i >= _agent.numContainers)
         return 0; 
     return _agent.containers[i].httpProxy.port;
+}
+
+std::string Config::getContainerEndpoint(int i) const {
+    assert(!_agentPt.empty());
+    if (i >= _agent.numContainers)
+        return std::string(); 
+    return _agent.containers[i].endpoint;
+}
+
+bool Config::getContainerVerifySSL(int i) const {
+    assert(!_agentPt.empty());
+    if (i >= _agent.numContainers)
+        return true; 
+    return _agent.containers[i].verifySSL;
 }
 
 int Config::getAgentNumWorkers() const {
@@ -1184,11 +1214,15 @@ void Config::printConfig() const {
                 "   - Url                     : %s\n"
                 "   - Capacity                : %luB\n"
                 "   - Http proxy              : %s\n"
+                "   - Endpoint (generic S3 only): %s\n"
+                "   - Verify SSL (generic S3 only): %s\n"
                 , getContainerId(i)
                 , ContainerTypeName[type]
                 , getContainerPath(i).c_str()
                 , getContainerCapacity(i)
                 , getContainerHttpProxyIP(i).empty()? "" : getContainerHttpProxyIP(i).append(":").append(std::to_string(getContainerHttpProxyPort(i))).c_str()
+                , getContainerEndpoint(i).c_str()
+                , getContainerVerifySSL(i)? "true" : "false"
             );
         }
         LOG(ERROR) << buf;

--- a/src/common/config.hh
+++ b/src/common/config.hh
@@ -67,6 +67,8 @@ public:
     std::string getContainerKey(int i) const;
     std::string getContainerHttpProxyIP(int i) const;
     unsigned short getContainerHttpProxyPort(int i) const;
+    std::string getContainerEndpoint(int i) const;
+    bool getContainerVerifySSL(int i) const;
     // agent.misc
     int getAgentNumWorkers() const;
     int getAgentNumZmqThread() const;
@@ -192,6 +194,8 @@ private:
         std::string region;
         std::string key;
         std::string keyId;
+        std::string endpoint;
+        bool verifySSL = true;
         struct {
             std::string ip;
             unsigned short port;

--- a/src/common/coordinator.cc
+++ b/src/common/coordinator.cc
@@ -288,14 +288,8 @@ unsigned char Coordinator::checkHostType() {
 
     if (checkHostTypeAction("http://100.100.100.200", &type, HOST_TYPE_ALI)) {
         // alibaba
-    } else if (checkHostTypeAction("http://metadata.google.internal", &type, HOST_TYPE_GCP)) {
-        // gcp
-    } else if (checkHostTypeAction("http://metadata.tencentyun.com", &type, HOST_TYPE_TENCENT)) {
-        // tencent
     } else if (checkHostTypeAction("http://169.254.169.254", &type)) {
         // aws, azure
-    } else if (checkHostTypeAction("http://169.254.169.254", &type, HOST_TYPE_HUAWEI)) {
-        // huawei
     } else {
         type = HostType::HOST_TYPE_ON_PREM;
     }

--- a/src/common/define.cc
+++ b/src/common/define.cc
@@ -3,7 +3,7 @@
 #include "define.hh"
 
 const char *CodingSchemeName[] = {
-    "RS",
+    "RS",          // 0
 
     "Unknown"
 };

--- a/src/common/define.hh
+++ b/src/common/define.hh
@@ -118,6 +118,7 @@ enum ContainerType {
     ALI_CONTAINER,
     AWS_CONTAINER,
     AZURE_CONTAINER,
+    GENERIC_S3_CONTAINER,  // 5
 
     UNKNOWN_CONTAINER,
 };

--- a/src/tools/zmq_reporter.c
+++ b/src/tools/zmq_reporter.c
@@ -42,25 +42,21 @@ const char *channel[] = {
 };
 
 const char *host_types[] = {
-    "On-prem",
+    "On-prem",       // 0
     "Alibaba",
     "AWS",
     "Azure",
-    "Tencent",
-    "Google",
-    "Huawei",
+    "Generic_S3",    // 5
 
     "Unknown"
 };
 
 const char *storage_types[] = {
-    "Local",
+    "Local",         // 0
     "Alibaba",
     "AWS",
     "Azure",
-    "Tencent",
-    "Google",
-    "Huawei",
+    "Generic_S3",    // 5
 
     "Unknown"
 };


### PR DESCRIPTION
## What is in the pull request?

- Add a new storage container type for generic S3 storage systems that support AWS S3 storage protocol (over HTTPS)
  - Required configurations: bucket name, region, key id, secret key, and S3 endpoint URL (e.g., https://127.0.0.1:59002)
  - Optional configurations: whether to verify the SSL/TLS certificate of the S3 endpoint, HTTP proxy endpoint and port

- Clean up unused/incorrect labels for proxy/agent host type and storage container type

## Code of Conduct

- [x] By submitting this issue, I agree to follow this project's [Code of Conduct](https://github.com/nexoedge/nexoedge/pull/CODE_OF_CONDUCT.md)