### PR TITLE
[Enhancement] Support authentication for Redis metadata store

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -71,6 +71,8 @@ In `proxy.ini`,
   - `ssl_client_key_path`: Path to an SSL/TLS client cert private key for connections to the metadata store, leave blank if SSL/TLS is not used
   - `ssl_trusted_certs_dir`: Path to an SSL/TLS-CA-cert-containing directory for connections to the metadata store, leave blank if not used 
   - `ssl_domain_name`: Domain name of the metadata store for SSL/TLS, leave blank if not used 
+  - `auth_user`: User name for authentication, leave blank for passwordless access
+  - `auth_password`: Password for authentication, leave blank for passwordless access
 - `recovery`: Recovery
   - `trigger_enabled`: Whether to enable background automatic recovery
   - `trigger_start_interval`: Time between trying to trigger a recovery operation (in seconds)

--- a/docs/user-doc/source/config.rst
+++ b/docs/user-doc/source/config.rst
@@ -79,6 +79,8 @@ In ``proxy.ini``,
     - ``ssl_client_key_path``: Path to an SSL/TLS client cert private key for connections to the metadata store, leave blank if SSL/TLS is not used
     - ``ssl_trusted_certs_dir``: Path to an SSL/TLS-CA-cert-containing directory for connections to the metadata store, leave blank if not used 
     - ``ssl_domain_name``: Domain name of the metadata store for SSL/TLS, leave blank if not used 
+    - ``auth_user``: User name for authentication, leave blank for passwordless access
+    - ``auth_password``: Password for authentication, leave blank for passwordless access
 - ``recovery``: Recovery
     - ``trigger_enabled``: Whether to enable background automatic recovery
     - ``trigger_start_interval``: Time between triggerings of recovery operation (in seconds)

--- a/sample/proxy.ini
+++ b/sample/proxy.ini
@@ -27,6 +27,10 @@ ssl_client_key_path =
 ssl_trusted_certs_dir =
 # metadata store SSL/TLS domain name (for redis, optional)
 ssl_domain_name =
+# metadata store user name, leave blank for passwordless access
+auth_user =
+# metadata store user password, leave blank for passwordless access
+auth_password =
 
 [recovery]
 # enable background recovery

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -318,6 +318,8 @@ void Config::setConfigPath (const char *generalPath, const char *proxyPath, cons
         default:
             break;
         }
+        _proxy.metastore.redis.auth.user = readString(_proxyPt, "metastore.auth_user");
+        _proxy.metastore.redis.auth.password = readString(_proxyPt, "metastore.auth_password");
         // auto recovery
         _proxy.recovery.enabled = readBool(_proxyPt, "recovery.trigger_enabled");
         _proxy.recovery.recoverIntv = std::max(readInt(_proxyPt, "recovery.trigger_start_interval"), 5);
@@ -778,6 +780,16 @@ std::string Config::getProxyMetaStoreSSLClientKeyPath() const {
 std::string Config::getProxyMetaStoreSSLDomainName() const {
     assert(!_proxyPt.empty());
     return _proxy.metastore.redis.ssl.domainName;
+}
+
+std::string Config::getProxyMetaStoreUser() const {
+    assert(!_proxyPt.empty());
+    return _proxy.metastore.redis.auth.user;
+}
+
+std::string Config::getProxyMetaStorePassword() const {
+    assert(!_proxyPt.empty());
+    return _proxy.metastore.redis.auth.password;
 }
 
 int Config::getProxyNumZmqThread() const {

--- a/src/common/config.hh
+++ b/src/common/config.hh
@@ -103,6 +103,8 @@ public:
     std::string getProxyMetaStoreSSLClientCertPath() const;
     std::string getProxyMetaStoreSSLClientKeyPath() const;
     std::string getProxyMetaStoreSSLDomainName() const;
+    std::string getProxyMetaStoreUser() const;
+    std::string getProxyMetaStorePassword() const;
     // proxy.misc
     int getProxyNumZmqThread() const;
     bool isRepairAtProxy() const;
@@ -291,6 +293,10 @@ private:
                     std::string clientCertPath;
                     std::string domainName;
                 } ssl;
+                struct {
+                    std::string user;
+                    std::string password;
+                } auth;
             } redis;
         } metastore;
         struct {

--- a/src/proxy/metastore/redis_metastore.hh
+++ b/src/proxy/metastore/redis_metastore.hh
@@ -161,6 +161,7 @@ private:
     std::string _taskScanIt;
     bool _endOfPendingWriteSet;
 
+    bool auth();
     void reconnect();
 
     int genFileKey(unsigned char namespaceId, const char *name, int nameLength, char key[]);


### PR DESCRIPTION
## What is in the pull request?

Strengthen metadata store security.

- Add the following configurations to support Redis metadata store with user-password authentication enabled ([see Redis 'AUTH' command authentication](https://redis.io/docs/latest/commands/auth/). In `proxy.ini`, under section `metastore`, 
  - `auth_user`: user name
  - `auth_password`: user password

## Code of Conduct

- [x] By submitting this issue, I agree to follow this project's [Code of Conduct](https://github.com/nexoedge/nexoedge/pull/CODE_OF_CONDUCT.md)